### PR TITLE
fix: harden proxy reliability

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,3 +8,8 @@ PRIVADO_SERVER=
 # Optional read-only status dashboard
 DASHBOARD_ENABLED=false
 DASHBOARD_PORT=8080
+
+# Optional tunnel DNS and end-to-end health probe settings
+DNS=9.9.9.9,149.112.112.112
+HEALTHCHECK_URL=https://api.ipify.org
+HEALTHCHECK_TIMEOUT=20

--- a/.github/README.md
+++ b/.github/README.md
@@ -6,7 +6,8 @@ A Docker image that connects to Privado VPN using WireGuard and exposes a SOCKS5
 
 - Fast WireGuard-based VPN connection
 - SOCKS5 proxy on port 1080
-- Automatic reconnection on connection loss
+- Automatic cleanup and reconnection after partial tunnel failures
+- End-to-end health checks for the tunnel, SOCKS DNS, and HTTPS trust
 - Optional read-only dashboard with tunnel and SOCKS5 status
 - Docker secrets support for credentials
 - Multi-platform support (amd64, arm64, arm/v7, arm/v6)
@@ -220,7 +221,9 @@ spec:
 | `SOCK_PORT` | SOCKS5 proxy port | `1080` |
 | `DASHBOARD_ENABLED` | Enables the optional read-only web dashboard | `false` |
 | `DASHBOARD_PORT` | Dashboard HTTP port when enabled | `8080` |
-| `DNS` | DNS servers to use | `193.110.81.0,185.253.5.0` |
+| `DNS` | Tunnel DNS servers to use | `9.9.9.9,149.112.112.112` |
+| `HEALTHCHECK_URL` | HTTPS hostname requested through SOCKS | `https://api.ipify.org` |
+| `HEALTHCHECK_TIMEOUT` | End-to-end probe timeout in seconds | `20` |
 | `DOCKER_NET` | Docker network subnet | auto-detected |
 | `LOCAL_SUBNETS` | Local subnets to bypass VPN | `192.168.0.0/16,172.16.0.0/12,10.0.0.0/8` |
 
@@ -273,12 +276,15 @@ curl --proxy socks5h://localhost:1080 https://ifconfig.me
 
 ### Container exits immediately
 Check logs with `docker logs <container>`. Common issues:
-- Missing credentials (PRIVADO_USERNAME, PRIVADO_PASSWORD, PRIVADO_SERVER)
+- Missing credentials (`PRIVADO_USERNAME`, `PRIVADO_PASSWORD`)
 - Invalid Privado VPN credentials
 - Server not found (check country code spelling)
 
 ### Connection drops
-The health check automatically attempts to reconnect. If issues persist:
+The health check verifies a recent WireGuard handshake and an HTTPS hostname
+request through SOCKS. If it fails, it asks supervisor to restart `main.sh`;
+startup first restores the original route and removes stale WireGuard policy and
+firewall state. If issues persist:
 - Check Privado VPN service status
 - Try a different server location
 - Verify your Privado VPN subscription is active

--- a/.github/workflows/publish-image.yaml
+++ b/.github/workflows/publish-image.yaml
@@ -12,7 +12,34 @@ permissions:
   packages: write
 
 jobs:
+  quality:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Validate shell scripts
+        run: |
+          bash -n scripts/*.sh tests/test_cleanup_integration.sh
+          shellcheck scripts/*.sh tests/test_cleanup_integration.sh
+
+      - name: Run tests
+        run: python3 -m unittest discover -s tests -v
+
+      - name: Build validation image
+        run: docker build --tag privado-proxy:test .
+
+      - name: Recreate stale tunnel state
+        run: |
+          docker run --rm --cap-add NET_ADMIN \
+            --volume "${PWD}/tests:/tests:ro" \
+            --entrypoint /bin/bash \
+            privado-proxy:test \
+            /tests/test_cleanup_integration.sh
+
   build-and-publish:
+    needs: quality
     runs-on: ubuntu-latest
 
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,8 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates curl jq microsocks supervisor iproute2 iptables python3 \
     net-tools gettext wireguard-tools procps \
+    && update-ca-certificates \
+    && test -s /etc/ssl/certs/ca-certificates.crt \
     && apt-get clean all && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Create user and group

--- a/kubernetes-example.yaml
+++ b/kubernetes-example.yaml
@@ -60,17 +60,21 @@ spec:
       capabilities:
         add:
         - NET_ADMIN
-    # Health check to verify the proxy is working
+    # End-to-end checks verify the tunnel, SOCKS proxy, remote DNS, and HTTPS.
     livenessProbe:
-      tcpSocket:
-        port: 1080
-      initialDelaySeconds: 30
+      exec:
+        command:
+        - /scripts/healthcheck.sh
+      initialDelaySeconds: 60
       periodSeconds: 60
+      timeoutSeconds: 30
     readinessProbe:
-      tcpSocket:
-        port: 1080
-      initialDelaySeconds: 10
-      periodSeconds: 10
+      exec:
+        command:
+        - /scripts/healthcheck.sh
+      initialDelaySeconds: 30
+      periodSeconds: 30
+      timeoutSeconds: 30
   # Pod-level security context to set the required sysctl
   securityContext:
     sysctls:

--- a/scripts/dante.sh
+++ b/scripts/dante.sh
@@ -10,5 +10,8 @@ setup_dante() {
 
 start_dante() {
   log "INFO: PROXY: Starting microsocks"
-  supervisorctl start microsocks
+  if ! supervisorctl start microsocks; then
+    log "ERROR: PROXY: Failed to start microsocks"
+    exit 1
+  fi
 }

--- a/scripts/healthcheck.sh
+++ b/scripts/healthcheck.sh
@@ -2,52 +2,64 @@
 
 set -e -u -o pipefail
 
-# Check if wg0 interface exists
+# VARS_FILE is overridable for local tests; containers use the installed file.
+# shellcheck source=/scripts/vars.sh
+source "${VARS_FILE:-/scripts/vars.sh}"
+
+request_recovery() {
+  if [[ -z "${PRIVADO_USERNAME}" ]] || [[ -z "${PRIVADO_PASSWORD}" ]]; then
+    return 0
+  fi
+
+  local main_status
+  main_status=$(supervisorctl status main 2>/dev/null || true)
+  if [[ "${main_status}" == *"RUNNING"* ]] || [[ "${main_status}" == *"STARTING"* ]]; then
+    return 0
+  fi
+
+  if supervisorctl start main >/dev/null 2>&1; then
+    echo "INFO: Requested a clean VPN reconnect through supervisor"
+  else
+    echo "WARNING: Could not request a VPN reconnect through supervisor"
+  fi
+}
+
+fail_healthcheck() {
+  echo "ERROR: $*"
+  request_recovery
+  exit 1
+}
+
 if ! ip link show wg0 &>/dev/null; then
-  echo "ERROR: WireGuard interface wg0 not found"
-  exit 1
+  fail_healthcheck "WireGuard interface wg0 not found"
 fi
 
-# Check if microsocks is running
 if ! pgrep -x microsocks >/dev/null; then
-  echo "ERROR: microsocks process not running"
-  exit 1
+  fail_healthcheck "microsocks process not running"
 fi
 
-# Verify WireGuard handshake is recent (within 3 minutes)
-latest_handshake=$(wg show wg0 latest-handshakes 2>/dev/null | awk '{print $2}')
+latest_handshake=$(wg show wg0 latest-handshakes 2>/dev/null | \
+  awk '$2 > latest { latest = $2 } END { print latest }' || true)
 
 if [[ -z "${latest_handshake}" ]] || [[ "${latest_handshake}" == "0" ]]; then
-  echo "WARNING: No WireGuard handshake detected"
-  # Try to restart the interface
-  wg-quick down wg0 2>/dev/null || true
-  wg-quick up wg0
-  sleep 5
-
-  # Check again
-  latest_handshake=$(wg show wg0 latest-handshakes 2>/dev/null | awk '{print $2}')
-  if [[ -z "${latest_handshake}" ]] || [[ "${latest_handshake}" == "0" ]]; then
-    echo "ERROR: Failed to establish WireGuard connection"
-    exit 1
-  fi
+  fail_healthcheck "No WireGuard handshake detected"
 fi
 
 now=$(date +%s)
 age=$((now - latest_handshake))
 
 if [[ ${age} -gt 180 ]]; then
-  echo "WARNING: WireGuard handshake is ${age}s old, attempting reconnect"
-  wg-quick down wg0 2>/dev/null || true
-  wg-quick up wg0
-  sleep 5
-
-  # Verify reconnection
-  latest_handshake=$(wg show wg0 latest-handshakes 2>/dev/null | awk '{print $2}')
-  if [[ -z "${latest_handshake}" ]] || [[ "${latest_handshake}" == "0" ]]; then
-    echo "ERROR: Reconnection failed"
-    exit 1
-  fi
+  fail_healthcheck "WireGuard handshake is ${age}s old"
 fi
 
-echo "OK: WireGuard connected, handshake ${age}s ago"
-exit 0
+# --socks5-hostname makes the proxy resolve the hostname through the tunnel.
+# The HTTPS request also proves that the image contains a usable CA bundle.
+if ! curl --fail --silent --show-error \
+  --max-time "${HEALTHCHECK_TIMEOUT}" \
+  --socks5-hostname "127.0.0.1:${SOCK_PORT}" \
+  --output /dev/null \
+  "${HEALTHCHECK_URL}"; then
+  fail_healthcheck "SOCKS hostname request failed for ${HEALTHCHECK_URL}"
+fi
+
+echo "OK: WireGuard connected, handshake ${age}s ago; SOCKS DNS and HTTPS succeeded"

--- a/scripts/iptables.sh
+++ b/scripts/iptables.sh
@@ -4,16 +4,21 @@ enforce_proxies_iptables() {
   log "INFO: Configuring iptables for proxy ports"
 
   # Allow incoming connections on SOCKS5 port
-  iptables -A INPUT -p tcp --dport ${SOCK_PORT} -j ACCEPT 2>/dev/null || true
-  iptables -A INPUT -p udp --dport ${SOCK_PORT} -j ACCEPT 2>/dev/null || true
+  iptables -C INPUT -p tcp --dport "${SOCK_PORT}" -j ACCEPT 2>/dev/null || \
+    iptables -A INPUT -p tcp --dport "${SOCK_PORT}" -j ACCEPT 2>/dev/null || true
+  iptables -C INPUT -p udp --dport "${SOCK_PORT}" -j ACCEPT 2>/dev/null || \
+    iptables -A INPUT -p udp --dport "${SOCK_PORT}" -j ACCEPT 2>/dev/null || true
 
   if [[ "${DASHBOARD_ENABLED,,}" == "true" ]]; then
-    iptables -A INPUT -p tcp --dport ${DASHBOARD_PORT} -j ACCEPT 2>/dev/null || true
+    iptables -C INPUT -p tcp --dport "${DASHBOARD_PORT}" -j ACCEPT 2>/dev/null || \
+      iptables -A INPUT -p tcp --dport "${DASHBOARD_PORT}" -j ACCEPT 2>/dev/null || true
   fi
 
   # Allow established connections
-  iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT 2>/dev/null || true
-  iptables -A OUTPUT -m state --state ESTABLISHED,RELATED -j ACCEPT 2>/dev/null || true
+  iptables -C INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT 2>/dev/null || \
+    iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT 2>/dev/null || true
+  iptables -C OUTPUT -m state --state ESTABLISHED,RELATED -j ACCEPT 2>/dev/null || \
+    iptables -A OUTPUT -m state --state ESTABLISHED,RELATED -j ACCEPT 2>/dev/null || true
 
   log "INFO: iptables configured"
 }
@@ -22,7 +27,7 @@ setup_dns() {
   log "INFO: Setting up DNS"
 
   # Use custom DNS if provided, otherwise use defaults
-  local dns_servers="${DNS:-193.110.81.0,185.253.5.0}"
+  local dns_servers="${DNS:-9.9.9.9,149.112.112.112}"
 
   # Clear existing resolv.conf
   echo "" > /etc/resolv.conf

--- a/scripts/main.sh
+++ b/scripts/main.sh
@@ -8,6 +8,27 @@ source /scripts/iptables.sh
 source /scripts/privado.sh
 source /scripts/dante.sh
 
+cleanup_after_failure() {
+  local status=$?
+  trap - EXIT
+
+  if [[ ${status} -ne 0 ]]; then
+    log "WARNING: PRIVADO: Startup failed; restoring the original network state"
+    supervisorctl stop microsocks >/dev/null 2>&1 || true
+    cleanup_wireguard_state
+  fi
+
+  exit "${status}"
+}
+
+trap cleanup_after_failure EXIT
+
+# A supervisor restart reuses the container network namespace. Stop the proxy
+# before opening the clear route, then remove stale tunnel state before any API
+# or DNS request is attempted.
+supervisorctl stop microsocks >/dev/null 2>&1 || true
+cleanup_wireguard_state
+
 print_settings
 set_timezone
 

--- a/scripts/privado.sh
+++ b/scripts/privado.sh
@@ -6,15 +6,151 @@ API_KEY="9f994c466340e8f2ed60a99396fecb6a"
 USER_AGENT="App: 3.0.0 (576942783), macOS: Version 12.4 (Build 21F79)"
 
 # Data directory for storing session data
-DATA_DIR="/run/privado"
+DATA_DIR=${DATA_DIR:-"/run/privado"}
 TOKEN_FILE="${DATA_DIR}/token.json"
 SERVERS_FILE="${DATA_DIR}/servers.json"
-WG_CONFIG="/etc/wireguard/wg0.conf"
+NETWORK_STATE_FILE="${DATA_DIR}/original-default-route"
+WG_CONFIG=${WG_CONFIG:-"/etc/wireguard/wg0.conf"}
 
 # Initialize data directory
 init_privado() {
-  mkdir -p ${DATA_DIR}
+  mkdir -p "${DATA_DIR}"
   mkdir -p /etc/wireguard
+}
+
+# Extract the gateway and interface from an iproute2 route line.
+route_gateway_and_interface() {
+  local route="${1}"
+  local gateway=""
+  local interface=""
+  local -a fields
+
+  read -r -a fields <<< "${route}"
+  for ((index = 0; index < ${#fields[@]}; index++)); do
+    case "${fields[index]}" in
+      via)
+        gateway="${fields[index + 1]:-}"
+        ;;
+      dev)
+        interface="${fields[index + 1]:-}"
+        ;;
+    esac
+  done
+
+  if [[ -n "${gateway}" ]] && [[ -n "${interface}" ]] && [[ "${interface}" != "wg0" ]]; then
+    printf '%s %s\n' "${gateway}" "${interface}"
+  fi
+}
+
+# Recover the pre-tunnel route from persisted state or the endpoint route that
+# survives when a container restarts inside the same network namespace.
+find_original_default_route() {
+  local gateway=""
+  local interface=""
+  local route=""
+  local endpoint=""
+  local endpoint_ip=""
+
+  if [[ -s "${NETWORK_STATE_FILE}" ]]; then
+    read -r gateway interface < "${NETWORK_STATE_FILE}" || true
+    if [[ -n "${gateway}" ]] && [[ -n "${interface}" ]] && [[ "${interface}" != "wg0" ]]; then
+      printf '%s %s\n' "${gateway}" "${interface}"
+      return 0
+    fi
+  fi
+
+  route=$(ip -4 route show default 2>/dev/null | awk '$0 !~ / dev wg0( |$)/ { print; exit }')
+  if [[ -n "${route}" ]]; then
+    route_gateway_and_interface "${route}"
+    return 0
+  fi
+
+  endpoint=$(wg show wg0 endpoints 2>/dev/null | awk 'NR == 1 { print $2 }' || true)
+  endpoint_ip="${endpoint%:*}"
+  if [[ "${endpoint_ip}" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    route=$(ip -4 route show table main "${endpoint_ip}/32" 2>/dev/null | head -1)
+  fi
+
+  if [[ -z "${route}" ]]; then
+    route=$(ip -4 route show table main 2>/dev/null | awk '
+      / via / && $0 !~ / dev wg0( |$)/ { print; exit }
+    ')
+  fi
+
+  route_gateway_and_interface "${route}"
+}
+
+# Remove every piece of WireGuard state that can outlive main.sh. This handles
+# both the current direct-default-route setup and legacy wg-quick fwmark rules.
+cleanup_wireguard_state() {
+  log "INFO: PRIVADO: Cleaning up stale WireGuard state"
+
+  local current_default=""
+  local recovery_route=""
+  local gateway=""
+  local interface=""
+  local endpoint=""
+  local endpoint_ip=""
+  local interface_address=""
+  local fwmark=""
+  local mark=""
+  local -a marks=("51820")
+
+  current_default=$(ip -4 route show default 2>/dev/null | head -1)
+  recovery_route=$(find_original_default_route || true)
+  read -r gateway interface <<< "${recovery_route}"
+
+  endpoint=$(wg show wg0 endpoints 2>/dev/null | awk 'NR == 1 { print $2 }' || true)
+  endpoint_ip="${endpoint%:*}"
+  interface_address=$(ip -o -4 addr show dev wg0 2>/dev/null | awk 'NR == 1 { print $4 }' || true)
+  fwmark=$(wg show wg0 fwmark 2>/dev/null || true)
+  if [[ -n "${fwmark}" ]] && [[ "${fwmark}" != "off" ]] && [[ "${fwmark}" != "51820" ]]; then
+    marks+=("${fwmark}")
+  fi
+
+  # Let wg-quick remove everything it recognizes, then explicitly remove
+  # partial state in case its config file is absent or incomplete.
+  wg-quick down wg0 >/dev/null 2>&1 || true
+
+  for mark in "${marks[@]}"; do
+    while ip -4 rule del not fwmark "${mark}" table "${mark}" 2>/dev/null; do :; done
+    ip -4 route flush table "${mark}" 2>/dev/null || true
+
+    while iptables -D OUTPUT ! -o wg0 -m mark ! --mark "${mark}" \
+      -m addrtype ! --dst-type LOCAL -j REJECT 2>/dev/null; do :; done
+    while iptables -t mangle -D POSTROUTING -m mark --mark "${mark}" \
+      -p udp -j CONNMARK --save-mark 2>/dev/null; do :; done
+  done
+
+  while ip -4 rule del table main suppress_prefixlength 0 2>/dev/null; do :; done
+  while iptables -t mangle -D PREROUTING -p udp -m conntrack \
+    --ctstate RELATED,ESTABLISHED -j CONNMARK --restore-mark 2>/dev/null; do :; done
+
+  if [[ -n "${interface_address}" ]]; then
+    while iptables -t raw -D PREROUTING ! -i wg0 -d "${interface_address}" \
+      -m addrtype ! --src-type LOCAL -j DROP 2>/dev/null; do :; done
+  fi
+
+  ip link del wg0 2>/dev/null || true
+
+  if [[ -z "${current_default}" ]] || [[ "${current_default}" == *" dev wg0"* ]]; then
+    if [[ -n "${gateway}" ]] && [[ -n "${interface}" ]]; then
+      if ip -4 route replace default via "${gateway}" dev "${interface}"; then
+        log "INFO: PRIVADO: Restored default route via ${gateway} dev ${interface}"
+      else
+        log "WARNING: PRIVADO: Failed to restore default route via ${gateway} dev ${interface}"
+      fi
+    else
+      log "WARNING: PRIVADO: No original default route could be recovered"
+    fi
+  fi
+
+  if [[ "${endpoint_ip}" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    ip -4 route del "${endpoint_ip}/32" 2>/dev/null || true
+  fi
+
+  rm -f "${NETWORK_STATE_FILE}"
+  return 0
 }
 
 # Login to Privado API and get access token
@@ -90,15 +226,18 @@ find_server() {
   local server_name
 
   # Convert query to lowercase for comparison
-  local query_lower=$(echo "${query}" | tr '[:upper:]' '[:lower:]')
+  local query_lower
+  query_lower=$(echo "${query}" | tr '[:upper:]' '[:lower:]')
 
   # Try to find by exact server name first (excluding maintenance servers)
   server_name=$(jq -r --arg query "${query}" '.[] | select(.maintenance == false) | select(.name == $query) | .name' "${SERVERS_FILE}" | head -1)
 
   # If not found, check if query is in country-city format (e.g., "nl-ams", "netherlands-amsterdam")
   if [[ -z "${server_name}" ]] && [[ "${query}" == *-* ]]; then
-    local country_part=$(echo "${query}" | cut -d'-' -f1 | tr '[:upper:]' '[:lower:]')
-    local city_part=$(echo "${query}" | cut -d'-' -f2- | tr '[:upper:]' '[:lower:]')
+    local country_part
+    local city_part
+    country_part=$(echo "${query}" | cut -d'-' -f1 | tr '[:upper:]' '[:lower:]')
+    city_part=$(echo "${query}" | cut -d'-' -f2- | tr '[:upper:]' '[:lower:]')
     
     # Only proceed if both parts are non-empty
     if [[ -n "${country_part}" ]] && [[ -n "${city_part}" ]]; then
@@ -205,9 +344,6 @@ get_wireguard_config() {
   # Construct endpoint from server IP and port
   WG_ENDPOINT="${WG_SERVER_IP}:${WG_SERVER_PORT}"
 
-  # Use configured DNS
-  WG_DNS="${DNS}"
-
   if [[ -z "${WG_PRIVATE_KEY}" ]] || [[ -z "${WG_ADDRESS}" ]] || [[ -z "${WG_SERVER_PUBLIC_KEY}" ]] || [[ -z "${WG_SERVER_IP}" ]]; then
     log "ERROR: PRIVADO: Incomplete WireGuard configuration received"
     log "DEBUG: Response: ${response}"
@@ -217,8 +353,6 @@ get_wireguard_config() {
   log "INFO: PRIVADO: WireGuard configuration obtained"
   log "INFO: PRIVADO: Interface IP: ${WG_ADDRESS}"
 
-  # Save server hostname for later use
-  PRIVADO_SERVER_HOSTNAME="${server_hostname}"
 }
 
 # Generate WireGuard configuration file
@@ -249,19 +383,43 @@ connect_privado() {
   ip link del wg0 2>/dev/null || true
 
   # Get current default gateway info
-  local default_gw default_if
-  default_gw=$(ip route | grep "^default" | awk '{print $3}' | head -1)
-  default_if=$(ip route | grep "^default" | awk '{print $5}' | head -1)
+  local default_route default_gw default_if
+  default_route=$(ip -4 route show default | head -1)
+  default_gw=$(awk '{ for (i = 1; i <= NF; i++) if ($i == "via") print $(i + 1) }' <<< "${default_route}")
+  default_if=$(awk '{ for (i = 1; i <= NF; i++) if ($i == "dev") print $(i + 1) }' <<< "${default_route}")
+
+  if [[ -z "${default_gw}" ]] || [[ -z "${default_if}" ]] || [[ "${default_if}" == "wg0" ]]; then
+    log "ERROR: PRIVADO: Cannot determine the original default route"
+    exit 1
+  fi
+
+  mkdir -p "${DATA_DIR}"
+  printf '%s %s\n' "${default_gw}" "${default_if}" > "${NETWORK_STATE_FILE}"
   log "INFO: PRIVADO: Original gateway: ${default_gw} via ${default_if}"
 
   # Create WireGuard interface
-  ip link add wg0 type wireguard
-  wg setconf wg0 "${WG_CONFIG}"
-  ip addr add "${WG_ADDRESS}/32" dev wg0
-  ip link set wg0 up
+  if ! ip link add wg0 type wireguard; then
+    log "ERROR: PRIVADO: Failed to create WireGuard interface"
+    exit 1
+  fi
+  if ! wg setconf wg0 "${WG_CONFIG}"; then
+    log "ERROR: PRIVADO: Failed to configure WireGuard interface"
+    exit 1
+  fi
+  if ! ip addr add "${WG_ADDRESS}/32" dev wg0; then
+    log "ERROR: PRIVADO: Failed to assign WireGuard address"
+    exit 1
+  fi
+  if ! ip link set wg0 up; then
+    log "ERROR: PRIVADO: Failed to bring up WireGuard interface"
+    exit 1
+  fi
 
   # Add route to VPN server via original gateway (so we can reach it)
-  ip route add "${WG_SERVER_IP}/32" via "${default_gw}" dev "${default_if}" 2>/dev/null || true
+  if ! ip -4 route replace "${WG_SERVER_IP}/32" via "${default_gw}" dev "${default_if}"; then
+    log "ERROR: PRIVADO: Failed to preserve the route to the VPN endpoint"
+    exit 1
+  fi
 
   # Add routes for local subnets to bypass VPN (required for Kubernetes cluster traffic)
   log "INFO: PRIVADO: Adding routes for local subnets"
@@ -287,8 +445,10 @@ connect_privado() {
   fi
 
   # Replace default route with WireGuard tunnel
-  ip route del default 2>/dev/null || true
-  ip route add default dev wg0
+  if ! ip -4 route replace default dev wg0; then
+    log "ERROR: PRIVADO: Failed to route traffic through WireGuard"
+    exit 1
+  fi
 
   if ! ip link show wg0 up &>/dev/null; then
     log "ERROR: PRIVADO: Failed to bring up WireGuard interface"
@@ -301,7 +461,7 @@ connect_privado() {
 # Disconnect from VPN
 disconnect_privado() {
   log "INFO: PRIVADO: Disconnecting WireGuard"
-  wg-quick down wg0 2>/dev/null || true
+  cleanup_wireguard_state
 }
 
 # Check if VPN connection is active

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 
 log() {
-  echo "$(date '+%Y-%m-%d %H:%M:%S') [${0##*/}] ${@}" >&2
+  printf '%s [%s] %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "${0##*/}" "$*" >&2
 }
 
 set_timezone() {
   [[ ${TZ} == $(cat /etc/timezone) ]] && return
   log "INFO: Setting timezone to ${TZ}"
-  ln -fs /usr/share/zoneinfo/${TZ} /etc/localtime
+  ln -fs "/usr/share/zoneinfo/${TZ}" /etc/localtime
   dpkg-reconfigure -fnoninteractive tzdata
 }

--- a/scripts/vars.sh
+++ b/scripts/vars.sh
@@ -28,16 +28,18 @@ PRIVADO_PASSWORD_FILE=${PRIVADO_PASSWORD_FILE:-'/run/secrets/privado_password'}
 
 # If no username is provided, check for a secret file
 if [[ -z ${PRIVADO_USERNAME} ]] && [[ -f ${PRIVADO_USERNAME_FILE} ]]; then
-  PRIVADO_USERNAME=$(cat ${PRIVADO_USERNAME_FILE})
+  PRIVADO_USERNAME=$(cat "${PRIVADO_USERNAME_FILE}")
 fi
 
 # If no password is provided, check for a secret file
 if [[ -z ${PRIVADO_PASSWORD} ]] && [[ -f ${PRIVADO_PASSWORD_FILE} ]]; then
-  PRIVADO_PASSWORD=$(cat ${PRIVADO_PASSWORD_FILE})
+  PRIVADO_PASSWORD=$(cat "${PRIVADO_PASSWORD_FILE}")
 fi
 
 # Network Settings
-DNS=${DNS:-'193.110.81.0,185.253.5.0'} # Default DNS0.EU
+DNS=${DNS:-'9.9.9.9,149.112.112.112'} # Default Quad9 resolvers
+HEALTHCHECK_URL=${HEALTHCHECK_URL:-'https://api.ipify.org'}
+HEALTHCHECK_TIMEOUT=${HEALTHCHECK_TIMEOUT:-'20'}
 
 # Networks
 DOCKER_NET=${DOCKER_NET:-''}
@@ -56,11 +58,20 @@ print_settings() {
   log "INFO: DASHBOARD_ENABLED: ${DASHBOARD_ENABLED}"
   log "INFO: DASHBOARD_PORT: ${DASHBOARD_PORT}"
   log "INFO: DNS: ${DNS}"
+  log "INFO: HEALTHCHECK_URL: ${HEALTHCHECK_URL}"
   log "INFO: PRIVADO_SERVER: ${PRIVADO_SERVER}"
   log "INFO: DOCKER_NET: ${DOCKER_NET}"
   log "INFO: LOCAL_SUBNETS: ${LOCAL_SUBNETS}"
   log "INFO: LOCALNET: ${LOCALNET}"
   # Don't log credentials
-  [[ -n ${PRIVADO_USERNAME} ]] && log "INFO: PRIVADO_USERNAME: [set]" || log "INFO: PRIVADO_USERNAME: [not set]"
-  [[ -n ${PRIVADO_PASSWORD} ]] && log "INFO: PRIVADO_PASSWORD: [set]" || log "INFO: PRIVADO_PASSWORD: [not set]"
+  if [[ -n ${PRIVADO_USERNAME} ]]; then
+    log "INFO: PRIVADO_USERNAME: [set]"
+  else
+    log "INFO: PRIVADO_USERNAME: [not set]"
+  fi
+  if [[ -n ${PRIVADO_PASSWORD} ]]; then
+    log "INFO: PRIVADO_PASSWORD: [set]"
+  else
+    log "INFO: PRIVADO_PASSWORD: [not set]"
+  fi
 }

--- a/tests/test_cleanup_integration.sh
+++ b/tests/test_cleanup_integration.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+set -e -u -o pipefail
+
+# shellcheck source=/scripts/utils.sh
+source /scripts/utils.sh
+# shellcheck source=/scripts/privado.sh
+source /scripts/privado.sh
+
+DATA_DIR=/tmp/privado-cleanup-test
+NETWORK_STATE_FILE="${DATA_DIR}/original-default-route"
+mkdir -p "${DATA_DIR}"
+
+default_route=$(ip -4 route show default | head -1)
+recovery_route=$(route_gateway_and_interface "${default_route}")
+read -r original_gateway original_interface <<< "${recovery_route}"
+printf '%s %s\n' "${original_gateway}" "${original_interface}" > "${NETWORK_STATE_FILE}"
+
+ip link add wg0 type dummy
+ip address add 10.0.0.2/32 dev wg0
+ip link set wg0 up
+ip -4 route add default table 51820 dev wg0
+ip -4 rule add table main suppress_prefixlength 0 priority 32764
+ip -4 rule add not fwmark 51820 table 51820 priority 32765
+iptables -I OUTPUT ! -o wg0 -m mark ! --mark 51820 \
+  -m addrtype ! --dst-type LOCAL -j REJECT
+iptables -t raw -I PREROUTING ! -i wg0 -d 10.0.0.2/32 \
+  -m addrtype ! --src-type LOCAL -j DROP
+iptables -t mangle -I POSTROUTING -m mark --mark 51820 \
+  -p udp -j CONNMARK --save-mark
+iptables -t mangle -I PREROUTING -p udp -m conntrack \
+  --ctstate RELATED,ESTABLISHED -j CONNMARK --restore-mark
+ip -4 route replace default dev wg0
+
+cleanup_wireguard_state
+
+ip -4 route show default | grep -Fq "via ${original_gateway} dev ${original_interface}"
+if ip link show wg0 >/dev/null 2>&1; then
+  echo "wg0 still exists after cleanup" >&2
+  exit 1
+fi
+if ip -4 rule show | grep -Eq '51820|suppress_prefixlength'; then
+  echo "WireGuard policy rules still exist after cleanup" >&2
+  exit 1
+fi
+if iptables -S OUTPUT | grep -Fq 'wg0'; then
+  echo "WireGuard OUTPUT rule still exists after cleanup" >&2
+  exit 1
+fi
+
+echo "OK: stale WireGuard routes, rules, interface, and firewall state were removed"

--- a/tests/test_network_scripts.py
+++ b/tests/test_network_scripts.py
@@ -1,0 +1,197 @@
+import os
+import subprocess
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+
+REPOSITORY = Path(__file__).resolve().parents[1]
+
+
+def write_executable(path, contents):
+    path.write_text(textwrap.dedent(contents), encoding="utf-8")
+    path.chmod(0o755)
+
+
+class NetworkCleanupTests(unittest.TestCase):
+    def test_cleanup_recovers_gateway_from_stale_endpoint_route(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            bin_dir = root / "bin"
+            bin_dir.mkdir()
+            command_log = root / "commands.log"
+
+            write_executable(
+                bin_dir / "ip",
+                """
+                #!/bin/bash
+                echo "ip $*" >> "${COMMAND_LOG}"
+                case "$*" in
+                  "-4 route show default")
+                    echo "default dev wg0 scope link"
+                    ;;
+                  "-4 route show table main 198.51.100.4/32")
+                    echo "198.51.100.4 via 172.17.0.1 dev eth0"
+                    ;;
+                  "-o -4 addr show dev wg0")
+                    echo "7: wg0 inet 10.0.0.2/32 scope global wg0"
+                    ;;
+                  "-4 route replace default via 172.17.0.1 dev eth0")
+                    exit 0
+                    ;;
+                esac
+                exit 1
+                """,
+            )
+            write_executable(
+                bin_dir / "wg",
+                """
+                #!/bin/bash
+                echo "wg $*" >> "${COMMAND_LOG}"
+                case "$*" in
+                  "show wg0 endpoints") echo "peer 198.51.100.4:51820" ;;
+                  "show wg0 fwmark") echo "51820" ;;
+                esac
+                """,
+            )
+            for command in ("wg-quick", "iptables"):
+                write_executable(
+                    bin_dir / command,
+                    f"""
+                    #!/bin/bash
+                    echo "{command} $*" >> "${{COMMAND_LOG}}"
+                    exit 1
+                    """,
+                )
+
+            environment = os.environ.copy()
+            environment.update(
+                {
+                    "COMMAND_LOG": str(command_log),
+                    "DATA_DIR": str(root / "run"),
+                    "PATH": f"{bin_dir}:{environment['PATH']}",
+                    "WG_CONFIG": str(root / "wg0.conf"),
+                }
+            )
+            result = subprocess.run(
+                [
+                    "bash",
+                    "-c",
+                    f'log() {{ :; }}; source "{REPOSITORY / "scripts/privado.sh"}"; '
+                    "cleanup_wireguard_state",
+                ],
+                capture_output=True,
+                check=False,
+                env=environment,
+                text=True,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            commands = command_log.read_text(encoding="utf-8")
+            self.assertIn("wg-quick down wg0", commands)
+            self.assertIn("ip -4 route flush table 51820", commands)
+            self.assertIn(
+                "ip -4 route replace default via 172.17.0.1 dev eth0",
+                commands,
+            )
+            self.assertIn("ip -4 route del 198.51.100.4/32", commands)
+
+
+class HealthcheckTests(unittest.TestCase):
+    def run_healthcheck(self, curl_exit="0"):
+        temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary.cleanup)
+        root = Path(temporary.name)
+        bin_dir = root / "bin"
+        bin_dir.mkdir()
+        command_log = root / "commands.log"
+        vars_file = root / "vars.sh"
+        vars_file.write_text(
+            "\n".join(
+                [
+                    "SOCK_PORT=1080",
+                    "HEALTHCHECK_URL=https://api.ipify.org",
+                    "HEALTHCHECK_TIMEOUT=20",
+                    "PRIVADO_USERNAME=test-user",
+                    "PRIVADO_PASSWORD=test-password",
+                ]
+            ),
+            encoding="utf-8",
+        )
+
+        write_executable(bin_dir / "ip", "#!/bin/bash\nexit 0\n")
+        write_executable(bin_dir / "pgrep", "#!/bin/bash\nexit 0\n")
+        write_executable(
+            bin_dir / "wg",
+            """
+            #!/bin/bash
+            echo "peer $(date +%s)"
+            """,
+        )
+        write_executable(
+            bin_dir / "curl",
+            """
+            #!/bin/bash
+            echo "curl $*" >> "${COMMAND_LOG}"
+            exit "${CURL_EXIT}"
+            """,
+        )
+        write_executable(
+            bin_dir / "supervisorctl",
+            """
+            #!/bin/bash
+            echo "supervisorctl $*" >> "${COMMAND_LOG}"
+            if [[ "$*" == "status main" ]]; then
+              echo "main EXITED"
+            fi
+            exit 0
+            """,
+        )
+
+        environment = os.environ.copy()
+        environment.update(
+            {
+                "COMMAND_LOG": str(command_log),
+                "CURL_EXIT": curl_exit,
+                "PATH": f"{bin_dir}:{environment['PATH']}",
+                "VARS_FILE": str(vars_file),
+            }
+        )
+        result = subprocess.run(
+            ["bash", str(REPOSITORY / "scripts/healthcheck.sh")],
+            capture_output=True,
+            check=False,
+            env=environment,
+            text=True,
+        )
+        return result, command_log.read_text(encoding="utf-8")
+
+    def test_healthcheck_proves_remote_dns_and_https_through_socks(self):
+        result, commands = self.run_healthcheck()
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("SOCKS DNS and HTTPS succeeded", result.stdout)
+        self.assertIn("--socks5-hostname 127.0.0.1:1080", commands)
+        self.assertIn("https://api.ipify.org", commands)
+
+    def test_failed_end_to_end_probe_requests_clean_reconnect(self):
+        result, commands = self.run_healthcheck(curl_exit="7")
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("SOCKS hostname request failed", result.stdout)
+        self.assertIn("supervisorctl status main", commands)
+        self.assertIn("supervisorctl start main", commands)
+
+
+class ImageTrustTests(unittest.TestCase):
+    def test_docker_build_asserts_ca_bundle(self):
+        dockerfile = (REPOSITORY / "Dockerfile").read_text(encoding="utf-8")
+
+        self.assertIn("ca-certificates", dockerfile)
+        self.assertIn("update-ca-certificates", dockerfile)
+        self.assertIn("test -s /etc/ssl/certs/ca-certificates.crt", dockerfile)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- restore the original default route and remove stale WireGuard interfaces, policy-routing rules, routing tables, and kill-switch firewall state before any API or DNS request
- persist recovery state during setup and clean partial networking state on failed starts
- install and assert the Debian CA trust bundle, use the proven Quad9 tunnel DNS pair, and validate SOCKS hostname resolution plus HTTPS in health checks
- gate image publication on shell checks, unit tests, a real image build, and a privileged stale-network recovery reproduction

## Validation

- `bash -n scripts/*.sh tests/test_cleanup_integration.sh`
- `shellcheck scripts/*.sh tests/test_cleanup_integration.sh`
- `python3 -m unittest discover -s tests -v` (11 passed)
- `docker compose config --quiet`
- `docker build --tag privado-proxy:issue-validation .`
- isolated `docker run --cap-add NET_ADMIN` reproduction verifies route, rule, interface, and firewall cleanup

Fixes #8
Fixes #9